### PR TITLE
added functions to deal with linearity test on params sens

### DIFF
--- a/ficetools/utils_funcs.py
+++ b/ficetools/utils_funcs.py
@@ -892,8 +892,6 @@ def dot_product_per_parameter_pair(params_me, params_il):
         dot_alpha_me = np.dot(dq_dalpha_me, alpha_v_me - alpha_v_il)
         dot_beta_me = np.dot(dq_dbeta_me, beta_v_me - beta_v_il)
 
-        print('%.2E' % Decimal(dot_alpha_me))
-        print('%.2E' % Decimal(dot_beta_me))
 
         fwd_v_alpha_me[f'{nametosum}{n}'].append(dq_dalpha_me)
         fwd_v_beta_me[f'{nametosum}{n}'].append(dq_dbeta_me)


### PR DESCRIPTION
Added two new functions to compute derivatives of the QoI (Quantity of Interest) with respect to alpha and beta and to calculate dot products between these derivatives and various inversions performed using MEaSUREs and ITSLIVE.

These functions, located in `ficetools/utils_funcs.py`, facilitate gathering information for each VAF(qoi) partition and for every velocity data product.
